### PR TITLE
close specialist track CFP

### DIFF
--- a/src/pages/program.mdx
+++ b/src/pages/program.mdx
@@ -3,56 +3,12 @@ title: Program
 layout: "../layouts/Page.astro"
 ---
 
-# Program
+import MailingListSignup from "../components/MailingListSignup.astro"
 
-Our call for proposals for talks and PyCon Fair stalls will come later in the year. Right now, though, you can apply to run a PyCon specialist track!
+# Coming soon!
 
-## Specialist track call for proposals
+Our call for specialist tracks has now closed, and our call for proposals will be opening in a few weeks' time.
 
-PyCon AU 2023 will run in Adelaide from 18 to 22 August. We are looking for expressions of interest from people willing to run specialist tracks!
+To find out when our Call for Proposals opens for PyCon AU 2023, follow us on <a href="https://fosstodon.org/@pyconau">Mastodon</a> or <a href="https://twitter.com/PyConAU">Twitter</a>, or sign up to the mailing list:
 
-Specialist tracks run on the Friday of PyCon AU - this time that will be Friday 18 August 2023. Each is centred around a central theme, with a schedule selected by independent organisers.
-
-In 2021 when the conference last ran, we had tracks on [Science, Data, and Analytics](https://2021.pycon.org.au/science-data-and-analytics/); [DevOops](https://2021.pycon.org.au/devoops/); [Education](https://2021.pycon.org.au/education/); and [Snakeoil Academy](https://2021.pycon.org.au/snakeoil-academy/). DjangoCon is another oftentime favourite.
-
-Our specialist track organisers did an amazing job, but we want to provide our attendees with the most awesome experience possible, and we believe that means opening the doors to potential new ideas. We want to hear from our previous specialist track organisers and others with similar experience, as well as people keen to get started in conference organising. We’d love to see submissions for tracks we’ve had in the past as well new suggestions for tracks we could feature.
-
-Examples of other ideas for specialist tracks include:
-
-- Something specialised within the data and science space, for example geoscience or life sciences
-- GLAM (Galleries, Libraries Archives and Museums)
-- COVID-centric projects
-
-If you’ve run a specialist track before, we encourage you to invite new faces as co-organisers. Succession planning and new ideas are always welcome.
-
-## What to expect when you’re expect(ed to run a specialist track)
-
-PyCon AU runs an integrated Call For Proposals (CFP), where speakers can submit to both the main conference and to the specialist tracks through the same process.
-
-As a specialist track organiser, you will promote the CFP, and help us make sure that the CFP makes its way in front of as many people as possible - including all the ones that you want to have on your track’s stage.
-
-Once the CFP closes, you will participate in the CFP review process, where you’ll need to review all talks submitted to your track, and may (but don’t need to) review talks submitted to the main conference and other tracks too.
-
-You will then select and plan your program, in consultation with the core team and other track organisers. Talks can be moved between the tracks (and the main conference) as needed, after discussion with the presenter, core team, and relevant track organisers.
-
-On the day, you will be the face of your specialist track. You will present opening and closing remarks, introduce speakers, and moderate questions. All of this will happen with the support of the conference and AV volunteers.
-
-All of the other infrastructure (venue, catering, ticketing, marketing, scheduling, sponsorship, AV, volunteers, and all those other fun things) will be handled by the PyCon AU core team. You will be working closely with us, so that we can all make sure your plans turn into reality. (Sadly, this sometimes means we have to say “no”, but hopefully not too often!)
-
-If you’ve got an idea that doesn’t follow the “standard” track-of-talks format, please let us know! We’d love to try new and interesting ideas. As noted above, we’ll need to work together to make sure they’re doable, and that the day runs as smoothly as possible.
-
-It is also important to note that as a specialist track organiser, you’ll be a part of the team working to make the conference happen, and one of the public faces of the conference. This means that we need to be able to trust that you’ll not only follow the code of conduct, but provide a model for the best behaviours we all wish to see in each other.
-
-## How to apply
-
-To propose a track, please email us at [program@pycon.org.au](mailto:program@pycon.org.au) before the end of **Monday 13 March 2023** anywhere on earth, and provide us the following information:
-
-- What is the focus of the track?
-- Who will be running the track (including contact details)? You must have at least two organisers.
-  - **If you want to get involved but don't have a co-organiser:** we can't accept a formal proposal from one person, but email us anyway and we'll do our best to put you in touch with someone.
-- Will you follow a “normal” track-of-talks structure, or a different structure?
-- Do you need any support from the PyCon AU committee, outside what you outlined above?
-
-We’ll acknowledge your proposal as soon as possible once we receive it. We’ll be in touch if we have any further questions or need any clarification.
-
-(Anywhere on earth means that this CFP is still open while the current date is 13 March 2023 in any time zone.)
+<MailingListSignup />


### PR DESCRIPTION
merge on or after the specialist track CFP closes: https://www.timeanddate.com/worldclock/fixedtime.html?msg=CFP+closes&iso=20230313T235959&p1=3399