### PR TITLE
Add Discord webhook for Pretalx updates

### DIFF
--- a/.github/workflows/update_schedule.yml
+++ b/.github/workflows/update_schedule.yml
@@ -20,6 +20,7 @@ jobs:
           PRETALX_TOKEN: ${{ secrets.PRETALX_TOKEN }}
       - run: git diff
       - uses: EndBug/add-and-commit@v4
+        id: add-and-commit
         with:
           add: |
             public/people
@@ -31,7 +32,11 @@ jobs:
           message: "Auto-update of schedule"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Send Discord notification
-        uses: distributhor/workflow-webhook@v3
+      - name: Notify discord
+        if: ${{ steps.add-and-commit.outputs.committed }}
+        uses: th0th/notify-discord@v0.4.1
         env:
-          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_JOB_NAME: "Update schedule"
+          GITHUB_JOB_STATUS: ${{ job.status }}

--- a/.github/workflows/update_schedule.yml
+++ b/.github/workflows/update_schedule.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Notify discord
-        if: ${{ steps.add-and-commit.outputs.committed }}
+        if: steps.add-and-commit.outputs.committed == 'true'
         uses: th0th/notify-discord@v0.4.1
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/update_schedule.yml
+++ b/.github/workflows/update_schedule.yml
@@ -31,3 +31,7 @@ jobs:
           message: "Auto-update of schedule"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Send Discord notification
+        uses: distributhor/workflow-webhook@v3
+        env:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}


### PR DESCRIPTION
According to [Discord's webhook docs](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks):

1. Open your Server Settings and head into the Integrations tab
2. Click the "Create Webhook" button to create a new webhook
3. Get the webhook URL for the server/channel you want to receive messages
4. Ensure to append `/github` to the end of the URL

Then on the GitHub side, we're not going to use the classic Web hook integration; we're doing this from an Action.

1. Make the changes listed in this commit (using a [GitHub Webhook action](https://github.com/marketplace/actions/workflow-webhook-action))
2. And set the `WEBHOOK_URL` secret fot the repo to the aforementioned URL