### PR TITLE
Bump git action

### DIFF
--- a/.github/workflows/update_schedule.yml
+++ b/.github/workflows/update_schedule.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           PRETALX_TOKEN: ${{ secrets.PRETALX_TOKEN }}
       - run: git diff
-      - uses: EndBug/add-and-commit@v4
+      - uses: EndBug/add-and-commit@v5.3.0
         id: add-and-commit
         with:
           add: |


### PR DESCRIPTION
The old version didn't have the committed output, stopping the webhook from firing