### PR TITLE
Revert katie clobber, update program redirect

### DIFF
--- a/.github/workflows/update_schedule.yml
+++ b/.github/workflows/update_schedule.yml
@@ -18,9 +18,6 @@ jobs:
           poetry run python schedule_sync.py
         env:
           PRETALX_TOKEN: ${{ secrets.PRETALX_TOKEN }}
-      - run: |
-          git reset src/content/sessions/ABGMQH.yml
-          git checkout src/content/sessions/ABGMQH.yml
       - run: git diff
       - uses: EndBug/add-and-commit@v5.3.0
         id: add-and-commit

--- a/src/pages/program/index.astro
+++ b/src/pages/program/index.astro
@@ -4,4 +4,4 @@ import Redirect from "../../components/Redirect.astro"
 // TODO: make this page redirect to the current day
 ---
 
-<Redirect href="/program/sprints/" />
+<Redirect href="/program/list/" />


### PR DESCRIPTION
Now that Pretalx is updated, we shouldn't need to special-case Katie's talk any more.

Further, it doesn't make sense for /program to redirect to sprints now the event is over, so redirect to the full program list instead.